### PR TITLE
🚨 doc(general):  Update getting-started.md to remove faq link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,6 +184,4 @@ Should return
 }
 ```
 
-### Related Articles
 
-* [FAQ](https://www.kintohub.com/faqs/)


### PR DESCRIPTION
Hi Noah,

Removed the section pointing to FAQ in the Getting Started page.

FAQ page is no longer there and is a broken link now in the Docs

Regards,
Ajesh